### PR TITLE
Add NotesBrowsingPage with owner-only delete functionality

### DIFF
--- a/backend/routes/noteRoutes.js
+++ b/backend/routes/noteRoutes.js
@@ -45,3 +45,26 @@ router.get('/notes', async (req, res) => {
 });
 
 module.exports = router;
+
+router.delete("/notes/:id", authMiddleware, async (req, res) => {
+  try {
+    const note = await Note.findById(req.params.id);
+
+    if (!note) {
+      return res.status(404).json({ message: "Note not found" });
+    }
+
+    // Check ownership
+    if (note.uploadedBy.toString() !== req.user.userId) {
+      return res
+        .status(403)
+        .json({ message: "You are not authorized to delete this note" });
+    }
+
+    await note.deleteOne();
+    res.status(200).json({ message: "Note deleted successfully" });
+  } catch (err) {
+    console.error("❌ Delete error:", err.message);
+    res.status(500).json({ message: "Server error" });
+  }
+});

--- a/frontend/src/components/NotesBrowsingPage.jsx
+++ b/frontend/src/components/NotesBrowsingPage.jsx
@@ -1,4 +1,6 @@
 import React, { useState, useEffect } from "react";
+import Navbar from "./Navbar";
+
 import {
   FaDownload,
   FaEye,


### PR DESCRIPTION
This PR resolves issue #58, which helps to ensure that only authenticated users can securely delete their own uploaded notes.

### How to Test
1. Start both frontend (`npm run dev`) and backend (`npm start`)
2. Navigate to `/browse` route
3. Try:
   - Searching by title, subject, or username
   - Filtering by subject
   - Sorting notes by newest/popular/title
   - Deleting your own uploaded note
4. Upload new notes via the upload page and verify they appear here

This feature brings a clean and interactive way for users to explore shared notes on the platform and sets a solid foundation for future community-based features like ratings, favorites, and comments.
