### PR TITLE
 add summary field to Notes schema and API responses (#116)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,4 +9,19 @@ CLOUDINARY_API_KEY=your-cloudinary-api-key
 CLOUDINARY_API_SECRET=your-cloudinary-api-secret
 CLOUDINARY_UPLOAD_PRESET=your-upload-preset
 CLOUDINARY_UPLOAD_FOLDER=your-upload-folder
+# MONGO_URI=mongodb+srv://Vipulyadav:yadav%40123456@notes-cluster.civjyyt.mongodb.net/notesdb?retryWrites=true&w=majority&appName=notes-cluster
+# JWT_SECRET=your_jwt_secret
+# PORT=3000
+# GOOGLE_CLIENT_ID=28604021907-l92sk446e4hk5uirkadrrvcglnf0gv01.apps.googleusercontent.com
+# GOOGLE_CLIENT_SECRET=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
+# FRONTEND_URL=http://localhost:5173
+# CLOUDINARY_CLOUD_NAME=daefnk9rw
+# CLOUDINARY_API_KEY=154599796612515
+# CLOUDINARY_API_SECRET=8la91lqi-hlmKj1NdlQXEHhyBbM
+# CLOUDINARY_UPLOAD_PRESET=notes_raw_preset
+# CLOUDINARY_UPLOAD_FOLDER=notesSharingFiles
+# RESEND_API_KEY=re_aN3Bemfw_28rH7T4UTgBGhnpmSp2mSLwQ
+# BACKEND_URL=http://localhost:3000
+
+
 

--- a/backend/models/Note.js
+++ b/backend/models/Note.js
@@ -14,6 +14,10 @@ const noteSchema = new mongoose.Schema({
     type: String,
     trim: true
   },
+  summary: {                        
+    type: String,
+    trim: true
+  },
   fileUrl: {
     type: String,
     required: true,
@@ -48,13 +52,11 @@ const noteSchema = new mongoose.Schema({
   timestamps: true
 });
 
-
 noteSchema.index({
   title: 'text',
   subject: 'text',
   description: 'text'
 });
-
 
 noteSchema.virtual('likes').get(function () {
   return this.likedBy.length;

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,3 +1,3 @@
-VITE_CLOUDINARY_CLOUD_NAME=your-cloudinary-cloud-name
-VITE_CLOUDINARY_PRESET=your-upload-preset
+VITE_CLOUDINARY_CLOUD_NAME=your_cloudinary_cloud_name
+VITE_CLOUDINARY_PRESET=your_upload_preset
 VITE_API_BASE_URL=http://localhost:3000


### PR DESCRIPTION
Closes #116

### Description
Added a new `summary` field to the Notes schema to store the AI-generated summary of each note. This field will allow enhanced frontend display and future features like search or preview.

### Changes Made
- Modified the Mongoose `Notes` model to include a `summary: String` field
- Ensured the `summary` field is included in relevant API responses
- Checked compatibility with existing routes and ensured no breaking changes

### Notes
- The `summary` field is optional and will remain `undefined` for older notes until backfilled
- Future implementation may include auto-generating this field via AI or backend service
